### PR TITLE
Fix label creation for multiple subtasks

### DIFF
--- a/plugin/agtd.vim
+++ b/plugin/agtd.vim
@@ -103,7 +103,7 @@ function! Agtd_insertTask()
     " Get project label as in p:pro:sub1:sub2
     if match (line,' p:\w*') == -1
         " Line has no label 
-        let lastCol = 0
+        let lastCol = 1000000
         let project = ""
         let col = 0
         while col != 4
@@ -122,7 +122,7 @@ function! Agtd_insertTask()
             let line = getline (pos)
             let col = match(line,'\u\+')
 
-            if col != lastCol 
+            if col < lastCol
                 " Project names in the same column are siblings, not an ancestor
                 let project = ":" . tolower(matchstr(line,'\u\+')) . project
                 let lastCol = col


### PR DESCRIPTION
Fixed a small bug in :GInsert behavior. In a project with many tasks
which each have multiple subtasks, the p:proj:task:subtask tag isn't
always created correctly due to the project/task tree being traversed
incorrectly.

This fix ensures that the project/task tree is always traversed in the
direction of the root of the tree.

Example tree which can produce error:

```
#Projects
; bla

    PROJA
        TASKA
            SUBTASKA
        TASKB
            SUBTASKB
            ; try to :GInsert task below
            @place Dummy item
```

Expected Result:

```
p:proja:taskb:subtaskb ...
```

Actual Result

```
p:proja:taska:subtaska:taskb:subtaskb ...
```

Cheers.
